### PR TITLE
🐛 Fix: Unexpectedly found nil while implicitly unwrapping an Optional…

### DIFF
--- a/ios/Sources/RNICleanableView/RNICleanableViewRegistry.swift
+++ b/ios/Sources/RNICleanableView/RNICleanableViewRegistry.swift
@@ -187,7 +187,7 @@ public final class RNICleanableViewRegistry {
       };
       
       RCTExecuteOnUIManagerQueue {
-        bridge.uiManager.addUIBlock { _,_ in
+        bridge.uiManager?.addUIBlock { _,_ in
           #if DEBUG
           guard !self._shouldAbortNextCleanup else { return };
           #endif


### PR DESCRIPTION
After upgrading to the expo latest with expo-dev-client, I found every time I press the "Reload" button, the app crashes.

```json
{
    "expo": "~50.0.14",
    "react-native": "0.73.6",
    "react-native-ios-context-menu": "^2.5.1",
    "react-native-ios-utilities": "^4.4.4",
    "zeego": "^1.10.0"
}
```

<img width="353" alt="image" src="https://github.com/dominicstop/react-native-ios-utilities/assets/18282328/fc150616-59a4-409e-b589-c1a79a00b14c">

After building the app in the XCode, I found the issue seems to be in the swift code, and the bug is gone after applying the fix.

<img width="1155" alt="image" src="https://github.com/dominicstop/react-native-ios-utilities/assets/18282328/5b26d2c8-ea8c-43db-8ef4-a41a444857d8">
