### PR TITLE
fix: rn 0.76 missing function RawPropsParser::iterateOverValues

### DIFF
--- a/ios/Sources/RNIBaseView/RNIBaseViewProps.cpp
+++ b/ios/Sources/RNIBaseView/RNIBaseViewProps.cpp
@@ -22,16 +22,11 @@ RNIBaseViewProps::RNIBaseViewProps(
   
   std::unordered_map<std::string, folly::dynamic> propsMap = std::move(sourceProps.propsMap);
 
-  const auto& dynamic = static_cast<folly::dynamic>(rawProps);
+  const auto& dynamicProps = static_cast<folly::dynamic>(rawProps);
 
-  for (const auto& pair : dynamic.items()) {
-      const auto& name = pair.first.getString();
-      shadowNodeProps->setProp(
-          context,
-          RAW_PROPS_KEY_HASH(name),
-          name.c_str(),
-          RawValue(pair.second));
-    }
+  for (const auto& pair : dynamicProps.items()) {
+    const auto& name = pair.first.getString();
+    propsMap[name] = pair.second;
   }
   
   this->propsMap = propsMap;

--- a/ios/Sources/RNIBaseView/RNIBaseViewProps.cpp
+++ b/ios/Sources/RNIBaseView/RNIBaseViewProps.cpp
@@ -22,14 +22,17 @@ RNIBaseViewProps::RNIBaseViewProps(
   
   std::unordered_map<std::string, folly::dynamic> propsMap = std::move(sourceProps.propsMap);
 
-  rawProps.iterateOverValues([&propsMap](
-    react::RawPropsPropNameHash hash,
-    const char *name,
-    const react::RawValue &value
-  ) {
-    std::string propName(name);
-    propsMap[propName] = (folly::dynamic)value;
-  });
+  const auto& dynamic = static_cast<folly::dynamic>(rawProps);
+
+  for (const auto& pair : dynamic.items()) {
+      const auto& name = pair.first.getString();
+      shadowNodeProps->setProp(
+          context,
+          RAW_PROPS_KEY_HASH(name),
+          name.c_str(),
+          RawValue(pair.second));
+    }
+  }
   
   this->propsMap = propsMap;
 }


### PR DESCRIPTION
`RawPropsParser::iterateOverValues` was removed in the react-native version 0.76 which is used in `RNIBaseViewProps.cpp`:
https://github.com/facebook/react-native/commit/1fda630d876ad719c86b8b0d6ec78dc3174c38fd#diff-4567be9d6b4faed9e58019b237d48741ff639a9bdc9b7629507c98e58729314aL125
