### PR TITLE
Fix: View was already initialized

### DIFF
--- a/ios/Sources/RNIBaseView/RNIBaseView.mm
+++ b/ios/Sources/RNIBaseView/RNIBaseView.mm
@@ -260,7 +260,7 @@ static BOOL SHOULD_LOG = NO;
       return [viewDelegateClass new];
     };
     
-    return [[viewDelegateClass new] initWithFrame:self.frame];
+    return [[viewDelegateClass alloc] initWithFrame:self.frame];
   }();
   
   viewDelegate.parentReactView = self;


### PR DESCRIPTION
## Description

This PR fixes a crash in `react-native-ios-utilities` that occurs during multiple re-renders, caused by improper initialization on the native side.

### Fix

The line: `[[viewDelegateClass new] initWithFrame:self.frame];` was replaced with: `[[viewDelegateClass alloc] initWithFrame:self.frame];`

This change eliminates an unnecessary extra call to init(), which was causing conflicts during re-initialization.

### Reason for Crash
The use of new implicitly calls alloc followed by init, and subsequently `initWithFrame:` is called again, leading to double initialization of the view. By explicitly using alloc with `initWithFrame:,` the redundant init call is avoided, ensuring proper initialization.

### Error

```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'View was already initialized: <RNIContextMenuViewContent: 0x3195bf800; frame = (0 0; 0 0); layer = <CALayer: 0x600002c50fe0>>'
*** First throw call stack:
(
	0   CoreFoundation                      0x000000010ef1857c __exceptionPreprocess + 172
	1   libobjc.A.dylib                     0x000000010222eda8 objc_exception_throw + 72
	2   Foundation                          0x0000000104e4e200 _userInfoForFileAndLine + 0
	3   UIKitCore                           0x00000001489a275c -[UIView _populateInitialTraitCollection:] + 284
	4   UIKitCore                           0x00000001489a2b40 UIViewCommonInitWithFrame + 564
	5   UIKitCore                           0x00000001489a28bc -[UIView initWithFrame:] + 124
	6   Studocu.debug.dylib                 0x00000001092e2970 $s29react_native_ios_context_menu25RNIContextMenuViewContentC5frameACSo6CGRectV_tcfc + 1344
	7   Studocu.debug.dylib                 0x00000001092e29d4 $s29react_native_ios_context_menu25RNIContextMenuViewContentC5frameACSo6CGRectV_tcfcTo + 56
	8   Studocu.debug.dylib                 0x00000001092fb330 __31-[RNIBaseView initViewDelegate]_block_invoke + 468
	9   Studocu.debug.dylib                 0x00000001092fb088 -[RNIBaseView initViewDelegate] + 1260
	10  Studocu.debug.dylib                 0x00000001092fb420 -[RNIBaseView initCommon] + 216
	11  Studocu.debug.dylib                 0x00000001092faab0 -[RNIBaseView initWithFrame:] + 512
	12  Studocu.debug.dylib                 0x0000000108b054c4 -[RCTComponentViewFactory createComponentViewWithComponentHandle:] + 756
	13  Studocu.debug.dylib                 0x0000000108b0dc54 -[RCTComponentViewRegistry _dequeueComponentViewWithComponentHandle:] + 356
	14  Studocu.debug.dylib                 0x0000000108b0d078 -[RCTComponentViewRegistry dequeueComponentViewWithComponentHandle:tag:] + 624
	15  Studocu.debug.dylib                 0x0000000108b4e000 _ZL27RCTPerformMountInstructionsRKNSt3__16vectorIN8facebook5react18ShadowViewMutationENS_9allocatorIS3_EEEEP24RCTComponentViewRegistryR41RCTMountingTransactionObserverCoordinatori + 260
	16  Studocu.debug.dylib                 0x0000000108b4def0 _ZZ41-[RCTMountingManager performTransaction:]ENK3$_1clERKN8facebook5react19MountingTransactionERKNS1_16SurfaceTelemetryE + 80
	17  Studocu.debug.dylib                 0x0000000108b4de94 _ZNSt3__18__invokeB8de180100IRZ41-[RCTMountingManager performTransaction:]E3$_1JRKN8facebook5react19MountingTransactionERKNS4_16SurfaceTelemetryEEEEDTclclsr3stdE7declvalIT_EEspclsr3stdE7declvalIT	18  Studocu.debug.dylib                 0x0000000108b4de3c _ZNSt3__128__invoke_void_return_wrapperIvLb1EE6__callB8de180100IJRZ41-[RCTMountingManager performTransaction:]E3$_1RKN8facebook5react19MountingTransactionERKNS6_16SurfaceTelemetryEEEEvDpOT_ + 40
	19  Studocu.debug.dylib                 0x0000000108b4de08 _ZNSt3__110__function12__alloc_funcIZ41-[RCTMountingManager performTransaction:]E3$_1NS_9allocatorIS2_EEFvRKN8facebook5react19MountingTransactionERKNS6_16SurfaceTelemetryEEEclB8de180100ES9_SC_ + 	20  Studocu.debug.dylib                 0x0000000108b4cc84 _ZNSt3__110__function6__funcIZ41-[RCTMountingManager performTransaction:]E3$_1NS_9allocatorIS2_EEFvRKN8facebook5react19MountingTransactionERKNS6_16SurfaceTelemetryEEEclES9_SC_ + 44
	21  Studocu.debug.dylib                 0x0000000108934ac8 _ZNKSt3__110__function12__value_funcIFvRKN8facebook5react19MountingTransactionERKNS3_16SurfaceTelemetryEEEclB8de180100ES6_S9_ + 84
	22  Studocu.debug.dylib                 0x0000000108933a2c _ZNKSt3__18functionIFvRKN8facebook5react19MountingTransactionERKNS2_16SurfaceTelemetryEEEclES5_S8_ + 40
	23  Studocu.debug.dylib                 0x000000010893385c _ZNK8facebook5react19TelemetryController15pullTransactionERKNSt3__18functionIFvRKNS0_19MountingTransactionERKNS0_16SurfaceTelemetryEEEESD_SD_ + 300
	24  Studocu.debug.dylib                 0x0000000108b4828c -[RCTMountingManager performTransaction:] + 564
	25  Studocu.debug.dylib                 0x0000000108b48008 -[RCTMountingManager initiateTransaction:] + 428
	26  Studocu.debug.dylib                 0x0000000108b479e4 __42-[RCTMountingManager scheduleTransaction:]_block_invoke + 324
	27  Studocu.debug.dylib                 0x000000010875a5d4 __RCTExecuteOnMainQueue_block_invoke + 40
	28  libdispatch.dylib                   0x0000000110e18ec0 _dispatch_call_block_and_release + 24
	29  libdispatch.dylib                   0x0000000110e1a7b8 _dispatch_client_callout + 16
	30  libdispatch.dylib                   0x0000000110e2a45c _dispatch_main_queue_drain + 1224
	31  libdispatch.dylib                   0x0000000110e29f84 _dispatch_main_queue_callback_4CF + 40
	32  CoreFoundation                      0x000000010ee7c2dc __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 12
	33  CoreFoundation                      0x000000010ee76838 __CFRunLoopRun + 1944
	34  CoreFoundation                      0x000000010ee75c24 CFRunLoopRunSpecific + 552
	35  GraphicsServices                    0x00000001246fbb10 GSEventRunModal + 160
	36  UIKitCore                           0x00000001484602fc -[UIApplication _run] + 796
	37  UIKitCore                           0x00000001484644f4 UIApplicationMain + 124
	38  Studocu.debug.dylib                 0x0000000107acea84 __debug_main_executable_dylib_entry_point + 96
	39  dyld                                0x0000000100801410 start_sim + 20
	40  ???                                 0x00000001009c2154 0x0 + 4305199444
	41  ???                                 0x420f000000000000 0x0 + 4760023331153903616
)
libc++abi: terminating due to uncaught exception of type NSException
```

