### PR TITLE
fix: support use_frameworks!

### DIFF
--- a/example/ios/IosUtilitiesExample.xcodeproj/project.pbxproj
+++ b/example/ios/IosUtilitiesExample.xcodeproj/project.pbxproj
@@ -8,13 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		00E356F31AD99517003FC87E /* IosUtilitiesExampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* IosUtilitiesExampleTests.m */; };
-		0C80B921A6F3F58F76C31292 /* libPods-IosUtilitiesExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5DCACB8F33CDC322A6C60F78 /* libPods-IosUtilitiesExample.a */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		50F9A525D930F86382B2B745 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 19AA0ED25D6BB099CBD865C9 /* PrivacyInfo.xcprivacy */; };
-		7699B88040F8A987B510C191 /* libPods-IosUtilitiesExample-IosUtilitiesExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 19F6CBCC0A4E27FBF8BF4A61 /* libPods-IosUtilitiesExample-IosUtilitiesExampleTests.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
+		E43B8F241B7170D0A1692212 /* Pods_IosUtilitiesExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD28D0067038B9B527295013 /* Pods_IosUtilitiesExample.framework */; };
+		FD822B08A8555533823EBF2E /* Pods_IosUtilitiesExample_IosUtilitiesExampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5D0B996396D8E177FEC1B8D3 /* Pods_IosUtilitiesExample_IosUtilitiesExampleTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -31,6 +31,8 @@
 		00E356EE1AD99517003FC87E /* IosUtilitiesExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IosUtilitiesExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* IosUtilitiesExampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = IosUtilitiesExampleTests.m; sourceTree = "<group>"; };
+		03BA90A1A38597F33A902C24 /* Pods-IosUtilitiesExample-IosUtilitiesExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IosUtilitiesExample-IosUtilitiesExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-IosUtilitiesExample-IosUtilitiesExampleTests/Pods-IosUtilitiesExample-IosUtilitiesExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		065BA58EA2F81E5CE672260C /* Pods-IosUtilitiesExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IosUtilitiesExample.release.xcconfig"; path = "Target Support Files/Pods-IosUtilitiesExample/Pods-IosUtilitiesExample.release.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* IosUtilitiesExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IosUtilitiesExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = IosUtilitiesExample/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = IosUtilitiesExample/AppDelegate.mm; sourceTree = "<group>"; };
@@ -39,13 +41,11 @@
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = IosUtilitiesExample/main.m; sourceTree = "<group>"; };
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = IosUtilitiesExample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		19AA0ED25D6BB099CBD865C9 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = IosUtilitiesExample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		19F6CBCC0A4E27FBF8BF4A61 /* libPods-IosUtilitiesExample-IosUtilitiesExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-IosUtilitiesExample-IosUtilitiesExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		3B4392A12AC88292D35C810B /* Pods-IosUtilitiesExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IosUtilitiesExample.debug.xcconfig"; path = "Target Support Files/Pods-IosUtilitiesExample/Pods-IosUtilitiesExample.debug.xcconfig"; sourceTree = "<group>"; };
-		5709B34CF0A7D63546082F79 /* Pods-IosUtilitiesExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IosUtilitiesExample.release.xcconfig"; path = "Target Support Files/Pods-IosUtilitiesExample/Pods-IosUtilitiesExample.release.xcconfig"; sourceTree = "<group>"; };
-		5B7EB9410499542E8C5724F5 /* Pods-IosUtilitiesExample-IosUtilitiesExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IosUtilitiesExample-IosUtilitiesExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-IosUtilitiesExample-IosUtilitiesExampleTests/Pods-IosUtilitiesExample-IosUtilitiesExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
-		5DCACB8F33CDC322A6C60F78 /* libPods-IosUtilitiesExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-IosUtilitiesExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5D0B996396D8E177FEC1B8D3 /* Pods_IosUtilitiesExample_IosUtilitiesExampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IosUtilitiesExample_IosUtilitiesExampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = IosUtilitiesExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		89C6BE57DB24E9ADA2F236DE /* Pods-IosUtilitiesExample-IosUtilitiesExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IosUtilitiesExample-IosUtilitiesExampleTests.release.xcconfig"; path = "Target Support Files/Pods-IosUtilitiesExample-IosUtilitiesExampleTests/Pods-IosUtilitiesExample-IosUtilitiesExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		88C13434723B2D633D04BF1A /* Pods-IosUtilitiesExample-IosUtilitiesExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IosUtilitiesExample-IosUtilitiesExampleTests.release.xcconfig"; path = "Target Support Files/Pods-IosUtilitiesExample-IosUtilitiesExampleTests/Pods-IosUtilitiesExample-IosUtilitiesExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		C6A86E6616A58A7FFF24F026 /* Pods-IosUtilitiesExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IosUtilitiesExample.debug.xcconfig"; path = "Target Support Files/Pods-IosUtilitiesExample/Pods-IosUtilitiesExample.debug.xcconfig"; sourceTree = "<group>"; };
+		CD28D0067038B9B527295013 /* Pods_IosUtilitiesExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IosUtilitiesExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -54,7 +54,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7699B88040F8A987B510C191 /* libPods-IosUtilitiesExample-IosUtilitiesExampleTests.a in Frameworks */,
+				FD822B08A8555533823EBF2E /* Pods_IosUtilitiesExample_IosUtilitiesExampleTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -62,7 +62,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0C80B921A6F3F58F76C31292 /* libPods-IosUtilitiesExample.a in Frameworks */,
+				E43B8F241B7170D0A1692212 /* Pods_IosUtilitiesExample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -105,8 +105,8 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				5DCACB8F33CDC322A6C60F78 /* libPods-IosUtilitiesExample.a */,
-				19F6CBCC0A4E27FBF8BF4A61 /* libPods-IosUtilitiesExample-IosUtilitiesExampleTests.a */,
+				CD28D0067038B9B527295013 /* Pods_IosUtilitiesExample.framework */,
+				5D0B996396D8E177FEC1B8D3 /* Pods_IosUtilitiesExample_IosUtilitiesExampleTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -145,10 +145,10 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				3B4392A12AC88292D35C810B /* Pods-IosUtilitiesExample.debug.xcconfig */,
-				5709B34CF0A7D63546082F79 /* Pods-IosUtilitiesExample.release.xcconfig */,
-				5B7EB9410499542E8C5724F5 /* Pods-IosUtilitiesExample-IosUtilitiesExampleTests.debug.xcconfig */,
-				89C6BE57DB24E9ADA2F236DE /* Pods-IosUtilitiesExample-IosUtilitiesExampleTests.release.xcconfig */,
+				C6A86E6616A58A7FFF24F026 /* Pods-IosUtilitiesExample.debug.xcconfig */,
+				065BA58EA2F81E5CE672260C /* Pods-IosUtilitiesExample.release.xcconfig */,
+				03BA90A1A38597F33A902C24 /* Pods-IosUtilitiesExample-IosUtilitiesExampleTests.debug.xcconfig */,
+				88C13434723B2D633D04BF1A /* Pods-IosUtilitiesExample-IosUtilitiesExampleTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -160,12 +160,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "IosUtilitiesExampleTests" */;
 			buildPhases = (
-				A55EABD7B0C7F3A422A6CC61 /* [CP] Check Pods Manifest.lock */,
+				48E223F8DD0F1B2857FCF274 /* [CP] Check Pods Manifest.lock */,
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
-				C59DA0FBD6956966B86A3779 /* [CP] Embed Pods Frameworks */,
-				F6A41C54EA430FDDC6A6ED99 /* [CP] Copy Pods Resources */,
+				64B15B579D06E5D6B4B5B96F /* [CP] Embed Pods Frameworks */,
+				638B8137AF40A8FF7F91EC97 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -181,13 +181,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "IosUtilitiesExample" */;
 			buildPhases = (
-				C38B50BA6285516D6DCD4F65 /* [CP] Check Pods Manifest.lock */,
+				97008FCA7432DA3F7DC704FE /* [CP] Check Pods Manifest.lock */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				00EEFC60759A1932668264C0 /* [CP] Embed Pods Frameworks */,
-				E235C05ADACE081382539298 /* [CP] Copy Pods Resources */,
+				EA927B4D21A410366ECFA978 /* [CP] Embed Pods Frameworks */,
+				26ABD96E06B46FAB5614E01D /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -271,24 +271,24 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		00EEFC60759A1932668264C0 /* [CP] Embed Pods Frameworks */ = {
+		26ABD96E06B46FAB5614E01D /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample/Pods-IosUtilitiesExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample/Pods-IosUtilitiesExample-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			name = "[CP] Embed Pods Frameworks";
+			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample/Pods-IosUtilitiesExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample/Pods-IosUtilitiesExample-resources-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample/Pods-IosUtilitiesExample-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample/Pods-IosUtilitiesExample-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		A55EABD7B0C7F3A422A6CC61 /* [CP] Check Pods Manifest.lock */ = {
+		48E223F8DD0F1B2857FCF274 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -310,7 +310,41 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		C38B50BA6285516D6DCD4F65 /* [CP] Check Pods Manifest.lock */ = {
+		638B8137AF40A8FF7F91EC97 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample-IosUtilitiesExampleTests/Pods-IosUtilitiesExample-IosUtilitiesExampleTests-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample-IosUtilitiesExampleTests/Pods-IosUtilitiesExample-IosUtilitiesExampleTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample-IosUtilitiesExampleTests/Pods-IosUtilitiesExample-IosUtilitiesExampleTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		64B15B579D06E5D6B4B5B96F /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample-IosUtilitiesExampleTests/Pods-IosUtilitiesExample-IosUtilitiesExampleTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample-IosUtilitiesExampleTests/Pods-IosUtilitiesExample-IosUtilitiesExampleTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample-IosUtilitiesExampleTests/Pods-IosUtilitiesExample-IosUtilitiesExampleTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		97008FCA7432DA3F7DC704FE /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -332,55 +366,21 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		C59DA0FBD6956966B86A3779 /* [CP] Embed Pods Frameworks */ = {
+		EA927B4D21A410366ECFA978 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample-IosUtilitiesExampleTests/Pods-IosUtilitiesExample-IosUtilitiesExampleTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample/Pods-IosUtilitiesExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample-IosUtilitiesExampleTests/Pods-IosUtilitiesExample-IosUtilitiesExampleTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample/Pods-IosUtilitiesExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample-IosUtilitiesExampleTests/Pods-IosUtilitiesExample-IosUtilitiesExampleTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		E235C05ADACE081382539298 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample/Pods-IosUtilitiesExample-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample/Pods-IosUtilitiesExample-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample/Pods-IosUtilitiesExample-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		F6A41C54EA430FDDC6A6ED99 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample-IosUtilitiesExampleTests/Pods-IosUtilitiesExample-IosUtilitiesExampleTests-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample-IosUtilitiesExampleTests/Pods-IosUtilitiesExample-IosUtilitiesExampleTests-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample-IosUtilitiesExampleTests/Pods-IosUtilitiesExample-IosUtilitiesExampleTests-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IosUtilitiesExample/Pods-IosUtilitiesExample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -416,7 +416,7 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5B7EB9410499542E8C5724F5 /* Pods-IosUtilitiesExample-IosUtilitiesExampleTests.debug.xcconfig */;
+			baseConfigurationReference = 03BA90A1A38597F33A902C24 /* Pods-IosUtilitiesExample-IosUtilitiesExampleTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -443,7 +443,7 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 89C6BE57DB24E9ADA2F236DE /* Pods-IosUtilitiesExample-IosUtilitiesExampleTests.release.xcconfig */;
+			baseConfigurationReference = 88C13434723B2D633D04BF1A /* Pods-IosUtilitiesExample-IosUtilitiesExampleTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
@@ -467,7 +467,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3B4392A12AC88292D35C810B /* Pods-IosUtilitiesExample.debug.xcconfig */;
+			baseConfigurationReference = C6A86E6616A58A7FFF24F026 /* Pods-IosUtilitiesExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -500,7 +500,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5709B34CF0A7D63546082F79 /* Pods-IosUtilitiesExample.release.xcconfig */;
+			baseConfigurationReference = 065BA58EA2F81E5CE672260C /* Pods-IosUtilitiesExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -580,6 +580,17 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers/platform/ios",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-NativeModulesApple/React_NativeModulesApple.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD = "";
 				LDPLUSPLUS = "";
@@ -607,11 +618,7 @@
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 					"-DRN_FABRIC_ENABLED",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -663,6 +670,17 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon-Samples/ReactCommon_Samples.framework/Headers/platform/ios",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-NativeModulesApple/React_NativeModulesApple.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
+					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD = "";
 				LDPLUSPLUS = "";
@@ -689,11 +707,7 @@
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 					"-DRN_FABRIC_ENABLED",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1240,7 +1240,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-ios-utilities (5.0.0-45):
+  - react-native-ios-utilities (5.0.0-46):
     - ComputableLayout (~> 0.7)
     - DGSwiftUtilities (~> 0.29)
     - DoubleConversion
@@ -1590,7 +1590,7 @@ PODS:
     - React-logger (= 0.75.2)
     - React-perflogger (= 0.75.2)
     - React-utils (= 0.75.2)
-  - RNScreens (3.34.0):
+  - RNScreens (4.3.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1611,9 +1611,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 3.34.0)
+    - RNScreens/common (= 4.3.0)
     - Yoga
-  - RNScreens/common (3.34.0):
+  - RNScreens/common (4.3.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1864,58 +1864,58 @@ SPEC CHECKSUMS:
   React-Core: facd883836d8d1cc1949d2053c58eab5fb22eb75
   React-CoreModules: f92a2cb11d22f6066823ca547c61e900325dfe44
   React-cxxreact: f5595a4cbfe5a4e9d401dffa2c1c78bbbbbe75e4
-  React-debug: 4a91c177b5b2efcc546fb50bc2f676f3f589efab
-  React-defaultsnativemodule: 6b666572abf5fe7fe87836a42776abd6ad5ed173
-  React-domnativemodule: 785d767c4edbb9f011b8c976271077759ca5c4aa
-  React-Fabric: a33cc1fdc62a3085774783bb30970531589d2028
-  React-FabricComponents: 98de5f94cbd35d407f4fc78855298b562d8289cb
-  React-FabricImage: 0ce8fd83844d9edef5825116d38f0e208b9ad786
-  React-featureflags: 37a78859ad71db758e2efdcbdb7384afefa8701e
-  React-featureflagsnativemodule: f94aacb52c463e200ee185bff90ae3b392e60263
-  React-graphics: c16f1bab97a5d473831a79360d84300e93a614e5
+  React-debug: 153b1899b6d9e2fde855577e1cd615f7448a03ac
+  React-defaultsnativemodule: 0145cb30bca08003329edff898818313c09434b7
+  React-domnativemodule: 40e86c0c1dec62f7e8b2e35d51fde8bb821c9de2
+  React-Fabric: 9be6d42b5a1f4353d9e23c2db8532d9e5ccfef4d
+  React-FabricComponents: 897223a1dc15b4e8fa402cba057536cb10852963
+  React-FabricImage: f4aaac50854c2ef195b79d1d4315b9e32c5ca853
+  React-featureflags: 357423aa521ff01107895810f8d9758f8147d64d
+  React-featureflagsnativemodule: 40e83b0832c6f973ffc822d59f93fbb7b9ab4577
+  React-graphics: e41a17337bf4f4dfba8f7315b8ca0a73296800d7
   React-hermes: 7801f8c0e12f326524b461dc368d3e74f3d2a385
-  React-idlecallbacksnativemodule: d81bb7b5d26cea9852a8edc6ad1979cd7ed0841f
-  React-ImageManager: 98a1e5b0b05528dde47ebcd953d916ac66d46c09
-  React-jserrorhandler: 08f1c3465a71a6549c27ad82809ce145ad52d4f1
+  React-idlecallbacksnativemodule: d2e95548c8913cb1484544dfa32b473e304e0f1f
+  React-ImageManager: d24c9e2b772504aafde31455c39585a03377dece
+  React-jserrorhandler: 571bbbb4569347172cc4c0985a493b7dade32634
   React-jsi: 161428ab2c706d5fcd9878d260ff1513fdb356ab
   React-jsiexecutor: abfdc7526151c6755f836235bbaa53b267a0803c
-  React-jsinspector: f0786053a1a258a4d8dde859d1a820c26ee686f0
-  React-jsitracing: 52b849a77d02e2dc262a3031454c23be8dabb4d9
+  React-jsinspector: 02ca2651458d686f47b0803d420fefc1b9c97213
+  React-jsitracing: a63093da2909d8ee0d5a2224534cf605fa7adecc
   React-logger: 8db32983d75dc2ad54f278f344ccb9b256e694fc
-  React-Mapbuffer: 1c08607305558666fd16678b85ef135e455d5c96
-  React-microtasksnativemodule: f13f03163b6a5ec66665dfe80a0df4468bb766a6
-  react-native-ios-utilities: c88705ae28f9e7b2d29dd5e9d7d118f6edcc8e3a
-  react-native-safe-area-context: f1fda705dfe14355f41933debb5932887e234cc5
-  React-nativeconfig: 57781b79e11d5af7573e6f77cbf1143b71802a6d
-  React-NativeModulesApple: 7ff2e2cfb2e5fa5bdedcecf28ce37e696c6ef1e1
+  React-Mapbuffer: db173bede5ac5cb1c82d4a6a8597477ba87c5648
+  React-microtasksnativemodule: a5cd87542a308060e645d337b036733c327dc01b
+  react-native-ios-utilities: c4b75b2d1d01d327a3f51d51597d090fe128e69a
+  react-native-safe-area-context: 4571abffff5db8a314b849a2c72aae5cba2e4c7a
+  React-nativeconfig: 5fc2b05a590eb704128f5a4fc8ea6fa7b847e6e8
+  React-NativeModulesApple: 88313414ddffd1758f76042733e8f0297acfd502
   React-perflogger: 8a360ccf603de6ddbe9ff8f54383146d26e6c936
-  React-performancetimeline: 3cfec915adcb3653a5a633b41e711903844c35d8
+  React-performancetimeline: 300691014905e8d25b36415fd2f248a2befcce61
   React-RCTActionSheet: 1c0e26a88eec41215089cf4436e38188cfe9f01a
   React-RCTAnimation: d87207841b1e2ae1389e684262ea8c73c887cb04
   React-RCTAppDelegate: 328e56399c4f1c3d20cfe547ea24ebded2b3a87f
   React-RCTBlob: 79b42cb7db55f34079297687a480dbcf37f023f6
-  React-RCTFabric: 27636a6a5fa5622159297fce26881945d3658cf6
+  React-RCTFabric: 6d2fa4a49b9f3505c387210d2391122c5f4ea32d
   React-RCTImage: 0c10a75de59f7384a2a55545d5f36fe783e6ecda
   React-RCTLinking: bf08f4f655bf777af292b8d97449072c8bb196ca
   React-RCTNetwork: 1b690846b40fc5685af58e088720657db6814637
   React-RCTSettings: 097e420926dd44153fb25174835b572aded224d6
   React-RCTText: d8fe2ae9f95b2ccd03b2f534286e938254791992
   React-RCTVibration: 976466dba32c0981a836e45ce38bcd4c8d6d924e
-  React-rendererconsistency: ee0d6f1b4420e1ad5bb01c02170e7ecbd278e307
-  React-rendererdebug: 7fbf02f30d1e0bb0d96d65cf2548219cb53b29b6
-  React-rncore: 7ffc5be03adbf0a5cbf1b654483f487a899cff08
-  React-RuntimeApple: e623f002e1871de30a443291171d3f2fb134a6ec
-  React-RuntimeCore: a67357d4f073b1dbe6fbefc5273072027f201e1c
+  React-rendererconsistency: c6085ef7593a14a3ca07b82c533e8ce368403748
+  React-rendererdebug: 945ef6d8128f429becb3769a81591c96e3802fd2
+  React-rncore: 14846f4dd48ba5056b11ab89f4a5498f6f02f20f
+  React-RuntimeApple: 171b7b35ec9dc97ba358d691bea07fc81795ca3e
+  React-RuntimeCore: 7dcad4be47b656fdd67f7a6a78cf746948a11890
   React-runtimeexecutor: 5bb52479abf8081086afb0397dc33dc97202a439
-  React-RuntimeHermes: 860cf64708a12a2fa62366fe51fe000121fa031b
-  React-runtimescheduler: fff88d51ad2c8815fc75930dbac224d680593e6b
-  React-utils: 81a715d9c0a2a49047e77a86f3a2247408540deb
-  ReactCodegen: 60973d382704c793c605b9be0fc7f31cb279442f
-  ReactCommon: 6ef348087d250257c44c0204461c03f036650e9b
-  RNScreens: de6e57426ba0e6cbc3fb5b4f496e7f08cb2773c2
+  React-RuntimeHermes: bfada6b4eb293117496b0b0ef6d31a8142649596
+  React-runtimescheduler: 9577260c8dd7c3c97eb6f5086441784fd5241f62
+  React-utils: f908da1113885e2c08b25247e0ea892c68e2eaf6
+  ReactCodegen: de94475c4712a61ba0b1e1c25eb54db32f56836d
+  ReactCommon: 8da2bad9c1e5901f7b5484e42e59578edeece142
+  RNScreens: 9ec20e849e0df1376c072235ff123f59cdf71287
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  Yoga: a1d7895431387402a674fd0d1c04ec85e87909b8
+  Yoga: 36d44f1d31d7c11be1067e5c7a70a12c2eed355c
 
 PODFILE CHECKSUM: 4addf976769fc8cc864326d863bd182501265a79
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/example/package.json
+++ b/example/package.json
@@ -17,7 +17,7 @@
     "react-native": "0.75.2",
     "react-native-codegen": "0.71.3",
     "react-native-safe-area-context": "^4.10.8",
-    "react-native-screens": "^3.34.0"
+    "react-native-screens": "4.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/ios/Sources/ObjcHelpers/RNIObjcUtils.mm
+++ b/ios/Sources/ObjcHelpers/RNIObjcUtils.mm
@@ -8,7 +8,11 @@
 #import <Foundation/Foundation.h>
 
 #import "RNIObjcUtils.h"
+#if __has_include(<react_native_ios_utilities/Swift.h>)
+#import <react_native_ios_utilities/Swift.h>
+#else
 #import "react-native-ios-utilities/Swift.h"
+#endif
 
 #import <React/RCTBridge.h>
 #import <React/RCTBridge+Private.h>

--- a/ios/Sources/ObjcHelpers/UIApplication+RNIHelpers.h
+++ b/ios/Sources/ObjcHelpers/UIApplication+RNIHelpers.h
@@ -16,9 +16,9 @@
 @class RCTScheduler;
 
 #if __cplusplus
-namespace facebook::react {
-  class UIManager;
-}
+ namespace facebook::react {
+   class UIManager;
+ }
 #endif
 
 @interface UIApplication (RNIHelpers)

--- a/ios/Sources/ObjcHelpers/UIView+RNIFabricHelpers.mm
+++ b/ios/Sources/ObjcHelpers/UIView+RNIFabricHelpers.mm
@@ -10,8 +10,15 @@
 #import <Foundation/Foundation.h>
 #import <objc/runtime.h>
 
-#import "react-native-ios-utilities/RNIObjcUtils.h"
-#import "react-native-ios-utilities/Swift.h"
+#if __has_include(<react_native_ios_utilities/RNIObjcUtils.h>)
+#import <react_native_ios_utilities/RNIObjcUtils.h>
+#import <react_native_ios_utilities/Swift.h>
+#else
+#import <react-native-ios-utilities/RNIObjcUtils.h>
+#import <react-native-ios-utilities/Swift.h>
+#endif
+
+
 
 #if __cplusplus && RCT_NEW_ARCH_ENABLED
 #import "UIView+RNIHelpers.h"

--- a/ios/Sources/ObjcHelpers/UIView+RNIHelpers.mm
+++ b/ios/Sources/ObjcHelpers/UIView+RNIHelpers.mm
@@ -8,14 +8,28 @@
 #import <objc/runtime.h>
 
 #import "UIView+RNIHelpers.h"
+
+#if __has_include(<react_native_ios_utilities/Swift.h>)
+#import <react_native_ios_utilities/Swift.h>
+#import <react_native_ios_utilities/RNIObjcUtils.h>
+#else
 #import "react-native-ios-utilities/Swift.h"
 #import "react-native-ios-utilities/RNIObjcUtils.h"
+#endif
 
 #if RCT_NEW_ARCH_ENABLED
+#if __has_include(<react_native_ios_utilities/UIView+RNIFabricHelpers.h>)
+#import <react_native_ios_utilities/UIView+RNIFabricHelpers.h>
+#else
 #import "react-native-ios-utilities/UIView+RNIFabricHelpers.h"
+#endif
 #import <React/RCTViewComponentView.h>
 #else
+#if __has_include(<react_native_ios_utilities/UIView+RNIPaperHelpers.h>)
+#import <react_native_ios_utilities/UIView+RNIPaperHelpers.h>
+#else
 #import "react-native-ios-utilities/UIView+RNIPaperHelpers.h"
+#endif
 #import <React/RCTView.h>
 #import <React/UIView+React.h>
 #import <React/RCTUIManager.h>

--- a/ios/Sources/ObjcHelpers/UIView+RNIPaperHelpers.mm
+++ b/ios/Sources/ObjcHelpers/UIView+RNIPaperHelpers.mm
@@ -7,9 +7,15 @@
 
 #import "UIView+RNIPaperHelpers.h"
 
+#if __has_include(<react_native_ios_utilities/RNIBaseView.h>)
+#import <react_native_ios_utilities/RNIBaseView.h>
+#import <react_native_ios_utilities/UIView+RNIHelpers.h>
+#import <react_native_ios_utilities/UIApplication+RNIHelpers.h>
+#else
 #import "react-native-ios-utilities/RNIBaseView.h"
 #import "react-native-ios-utilities/UIView+RNIHelpers.h"
 #import "react-native-ios-utilities/UIApplication+RNIHelpers.h"
+#endif
 
 #import <React/RCTBridge.h>
 #import <React/RCTBridge+Private.h>

--- a/ios/Sources/RNIBaseView/RNIBaseView+KVC.h
+++ b/ios/Sources/RNIBaseView/RNIBaseView+KVC.h
@@ -1,0 +1,12 @@
+#import "RNIBaseView.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNIBaseView (KVC)
+
+- (id)valueForUndefinedKey:(NSString *)key;
+- (void)setValue:(id)value forUndefinedKey:(NSString *)key;
+
+@end
+
+NS_ASSUME_NONNULL_END 

--- a/ios/Sources/RNIBaseView/RNIBaseView+KVC.mm
+++ b/ios/Sources/RNIBaseView/RNIBaseView+KVC.mm
@@ -1,0 +1,39 @@
+#import "RNIBaseView.h"
+
+@implementation RNIBaseView (KVC)
+
+- (id)valueForUndefinedKey:(NSString *)key
+{
+#if RCT_NEW_ARCH_ENABLED
+  if ([key isEqualToString:@"reactEventHandler"]) {
+    // Return a dummy event handler block for Fabric
+    return @{
+      @"onDidSetViewID": [^(id value) {} copy],
+      @"onViewWillRecycle": [^(id value) {} copy],
+      @"onRawNativeEvent": [^(id value) {} copy]
+    };
+  }
+  
+  if ([key isEqualToString:@"reactPropHandler"]) {
+    // Return a dummy prop handler for Fabric
+    return @{
+      @"propName": [NSNull null]
+    };
+  }
+#endif
+  return [super valueForUndefinedKey:key];
+}
+
+- (void)setValue:(id)value forUndefinedKey:(NSString *)key
+{
+#if RCT_NEW_ARCH_ENABLED
+  if ([key isEqualToString:@"reactEventHandler"] ||
+      [key isEqualToString:@"reactPropHandler"]) {
+    // No-op for Fabric
+    return;
+  }
+#endif
+  [super setValue:value forUndefinedKey:key];
+}
+
+@end

--- a/ios/Sources/RNIBaseView/RNIBaseView.h
+++ b/ios/Sources/RNIBaseView/RNIBaseView.h
@@ -6,9 +6,17 @@
 //
 
 #import <UIKit/UIKit.h>
+
+
+#if __has_include(<react_native_ios_utilities/RNIRegistrableView.h>)
+#import "react_native_ios_utilities/RNIRegistrableView.h"
+#import "react_native_ios_utilities/RNIViewCommandRequestHandling.h"
+#import "react_native_ios_utilities/RNIContentViewParentDelegate.h"
+#else
 #import "react-native-ios-utilities/RNIRegistrableView.h"
 #import "react-native-ios-utilities/RNIViewCommandRequestHandling.h"
 #import "react-native-ios-utilities/RNIContentViewParentDelegate.h"
+#endif
 
 #if RCT_NEW_ARCH_ENABLED
 #import <React/RCTViewComponentView.h>

--- a/ios/Sources/RNIBaseView/RNIBaseView.mm
+++ b/ios/Sources/RNIBaseView/RNIBaseView.mm
@@ -6,19 +6,31 @@
 //
 
 #import "RNIBaseView.h"
-#import "react-native-ios-utilities/Swift.h"
 
 #import <objc/runtime.h>
 
-#import "react-native-ios-utilities/RNIUtilitiesModule.h"
-#import "react-native-ios-utilities/RNIViewRegistry.h"
+#if __has_include(<react_native_ios_utilities/RNIUtilitiesModule.h>)
+#import <react_native_ios_utilities/Swift.h>
+#import <react_native_ios_utilities/RNIUtilitiesModule.h>
+#import <react_native_ios_utilities/RNIViewRegistry.h>
+#import <react_native_ios_utilities/RNIContentViewParentDelegate.h>
+#import <react_native_ios_utilities/RNIViewCommandRequestHandling.h>
 
+#import <react_native_ios_utilities/RNIObjcUtils.h>
+#import <react_native_ios_utilities/UIApplication+RNIHelpers.h>
+#import <react_native_ios_utilities/UIView+RNIHelpers.h>
+
+#else
+#import <react-native-ios-utilities/Swift.h>
+#import <react-native-ios-utilities/RNIUtilitiesModule.h>
+#import <react-native-ios-utilities/RNIViewRegistry.h>
 #import "react-native-ios-utilities/RNIContentViewParentDelegate.h"
 #import "react-native-ios-utilities/RNIViewCommandRequestHandling.h"
 
 #import "react-native-ios-utilities/RNIObjcUtils.h"
 #import "react-native-ios-utilities/UIApplication+RNIHelpers.h"
 #import "react-native-ios-utilities/UIView+RNIHelpers.h"
+#endif
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #include "RNIBaseViewState.h"

--- a/ios/Sources/RNIBaseView/RNIBaseView.mm
+++ b/ios/Sources/RNIBaseView/RNIBaseView.mm
@@ -54,8 +54,13 @@
 #import "RNIBaseViewPaperEventHandler.h"
 #import "RNIBaseViewPaperPropHandler.h"
 
+#if __has_include("react_native_ios_utilities/RNIBaseViewPaperPropHolder.h")
+#import "react_native_ios_utilities/RNIBaseViewPaperPropHolder.h"
+#import "react_native_ios_utilities/UIView+RNIPaperHelpers.h"
+#else
 #import "react-native-ios-utilities/RNIBaseViewPaperPropHolder.h"
 #import "react-native-ios-utilities/UIView+RNIPaperHelpers.h"
+#endif
 
 #import <React/UIView+React.h>
 #import <React/RCTShadowView.h>

--- a/ios/Sources/RNIBaseView/RNIBaseView.mm
+++ b/ios/Sources/RNIBaseView/RNIBaseView.mm
@@ -272,7 +272,7 @@ static BOOL SHOULD_LOG = NO;
       return [viewDelegateClass new];
     };
     
-    return [[viewDelegateClass new] initWithFrame:self.frame];
+    return [[viewDelegateClass alloc] initWithFrame:self.frame];
   }();
   
   viewDelegate.parentReactView = self;

--- a/ios/Sources/RNIBaseView/RNIBaseViewPaperEventHandler.m
+++ b/ios/Sources/RNIBaseView/RNIBaseViewPaperEventHandler.m
@@ -10,7 +10,11 @@
 #import "RNIBaseViewPaperEventHolder.h"
 #import "RNIBaseView.h"
 
-#import "react-native-ios-utilities/RNIObjcUtils.h"
+#if __has_include(<react_native_ios_utilities/RNIObjcUtils.h>)
+#import <react_native_ios_utilities/RNIObjcUtils.h>
+#else
+#import <react-native-ios-utilities/RNIObjcUtils.h>
+#endif
 
 #import <objc/runtime.h>
 

--- a/ios/Sources/RNIBaseView/RNIBaseViewPaperEventHolder.m
+++ b/ios/Sources/RNIBaseView/RNIBaseViewPaperEventHolder.m
@@ -9,7 +9,11 @@
 #import "RNIBaseViewPaperEventHolder.h"
 #import "RNIBaseViewPaperEventHandler.h"
 
-#import "react-native-ios-utilities/RNIObjcUtils.h"
+#if __has_include(<react_native_ios_utilities/RNIObjcUtils.h>)
+#import <react_native_ios_utilities/RNIObjcUtils.h>
+#else
+#import <react-native-ios-utilities/RNIObjcUtils.h>
+#endif
 
 #if DEBUG
 #import "RNIBaseView.h"

--- a/ios/Sources/RNIBaseView/RNIBaseViewPaperPropHandler.m
+++ b/ios/Sources/RNIBaseView/RNIBaseViewPaperPropHandler.m
@@ -10,7 +10,11 @@
 #import "RNIBaseViewPaperPropHolder.h"
 #import "RNIBaseView.h"
 
-#import "react-native-ios-utilities/RNIObjcUtils.h"
+#if __has_include(<react_native_ios_utilities/RNIObjcUtils.h>)
+#import <react_native_ios_utilities/RNIObjcUtils.h>
+#else
+#import <react-native-ios-utilities/RNIObjcUtils.h>
+#endif
 
 #import <objc/runtime.h>
 

--- a/ios/Sources/RNIBaseView/RNIBaseViewPaperPropHolder.m
+++ b/ios/Sources/RNIBaseView/RNIBaseViewPaperPropHolder.m
@@ -6,7 +6,11 @@
 //
 
 #import "RNIBaseViewPaperPropHolder.h"
-#import "react-native-ios-utilities/RNIObjcUtils.h"
+#if __has_include(<react_native_ios_utilities/RNIObjcUtils.h>)
+#import <react_native_ios_utilities/RNIObjcUtils.h>
+#else
+#import <react-native-ios-utilities/RNIObjcUtils.h>
+#endif
 
 #if !RCT_NEW_ARCH_ENABLED
 #import "RNIBaseViewPaperPropHolder.h"

--- a/ios/Sources/RNIBaseView/RNIBaseViewUtils.h
+++ b/ios/Sources/RNIBaseView/RNIBaseViewUtils.h
@@ -5,8 +5,16 @@
 //  Created by Dominic Go on 5/14/24.
 //
 
+#if RCT_NEW_ARCH_ENABLED
+#define RNI_EXPORT_VIEW_PROPERTY(propName, type) \
+  RCT_CUSTOM_VIEW_PROPERTY(propName, id, RNIBaseView){}
+
+#define RNI_EXPORT_VIEW_EVENT(eventName, type) \
+  RCT_CUSTOM_VIEW_PROPERTY(eventName, id, RNIBaseView){}
+#else  
 #define RNI_EXPORT_VIEW_PROPERTY(propName, type) \
   RCT_REMAP_VIEW_PROPERTY(propName, reactPropHandler.propName, type)
-  
+
 #define RNI_EXPORT_VIEW_EVENT(eventName, type) \
   RCT_REMAP_VIEW_PROPERTY(eventName, reactEventHandler.eventName, type)
+#endif

--- a/ios/Sources/RNIDetachedView/RNIDetachedView.h
+++ b/ios/Sources/RNIDetachedView/RNIDetachedView.h
@@ -5,7 +5,11 @@
 //  Created by Dominic Go on 8/24/24.
 //
 
+#if __has_include(<react_native_ios_utilities/RNIBaseView.h>)
+#import <react_native_ios_utilities/RNIBaseView.h>
+#else
 #import <react-native-ios-utilities/RNIBaseView.h>
+#endif
 
 #if RCT_NEW_ARCH_ENABLED
 #import <React/RCTViewComponentView.h>

--- a/ios/Sources/RNIDetachedView/RNIDetachedView.mm
+++ b/ios/Sources/RNIDetachedView/RNIDetachedView.mm
@@ -7,17 +7,28 @@
 
 #import "RNIDetachedView.h"
 
-#import "react-native-ios-utilities/Swift.h"
-#import "react-native-ios-utilities/RNIContentViewParentDelegate.h"
-
-#import "react-native-ios-utilities/UIApplication+RNIHelpers.h"
-#import "react-native-ios-utilities/RNIObjcUtils.h"
+#if __has_include(<react_native_ios_utilities/Swift.h>)
+#import <react_native_ios_utilities/Swift.h>
+#import <react_native_ios_utilities/RNIContentViewParentDelegate.h>
+#import <react_native_ios_utilities/UIApplication+RNIHelpers.h>
+#import <react_native_ios_utilities/RNIObjcUtils.h>
+#else
+#import <react-native-ios-utilities/Swift.h>
+#import <react-native-ios-utilities/RNIContentViewParentDelegate.h>
+#import <react-native-ios-utilities/UIApplication+RNIHelpers.h>
+#import <react-native-ios-utilities/RNIObjcUtils.h>
+#endif
 
 #if RCT_NEW_ARCH_ENABLED
 #include "RNIDetachedViewComponentDescriptor.h"
 
-#include "react-native-ios-utilities/RNIBaseViewState.h"
-#include "react-native-ios-utilities/RNIBaseViewProps.h"
+#if __has_include(<react_native_ios_utilities/RNIBaseViewState.h>)
+#import <react_native_ios_utilities/RNIBaseViewState.h>
+#import <react_native_ios_utilities/RNIBaseViewProps.h>
+#else
+#include <react-native-ios-utilities/RNIBaseViewState.h>
+#include <react-native-ios-utilities/RNIBaseViewProps.h>
+#endif
 
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>

--- a/ios/Sources/RNIDetachedView/RNIDetachedViewComponentDescriptor.h
+++ b/ios/Sources/RNIDetachedView/RNIDetachedViewComponentDescriptor.h
@@ -11,7 +11,11 @@
 #include "RNIDetachedViewShadowNode.h"
 #include "RNIBaseViewComponentDescriptor.h"
 
-#include "react-native-ios-utilities/RNIBaseViewState.h"
+#if __has_include(<react_native_ios_utilities/RNIBaseViewState.h>)
+#import <react_native_ios_utilities/RNIBaseViewState.h>
+#else
+#include <react-native-ios-utilities/RNIBaseViewState.h>
+#endif
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
 

--- a/ios/Sources/RNIDetachedView/RNIDetachedViewManager.mm
+++ b/ios/Sources/RNIDetachedView/RNIDetachedViewManager.mm
@@ -8,7 +8,11 @@
 #import "RNIDetachedView.h"
 #import <objc/runtime.h>
 
+#if __has_include(<react_native_ios_utilities/RNIBaseViewUtils.h>)
+#import <react_native_ios_utilities/RNIBaseViewUtils.h>
+#else
 #import "react-native-ios-utilities/RNIBaseViewUtils.h"
+#endif
 
 #import "RCTBridge.h"
 #import <React/RCTViewManager.h>

--- a/ios/Sources/RNIDetachedView/RNIDetachedViewManager.mm
+++ b/ios/Sources/RNIDetachedView/RNIDetachedViewManager.mm
@@ -29,7 +29,7 @@ RCT_EXPORT_MODULE(RNIDetachedView)
 #ifndef RCT_NEW_ARCH_ENABLED
 - (UIView *)view
 {
-  return [[RNIDetachedView new] initWithBridge:self.bridge];
+  return [[RNIDetachedView alloc] initWithBridge:self.bridge];
 }
 #endif
 

--- a/ios/Sources/RNIDetachedView/RNIDetachedViewShadowNode.h
+++ b/ios/Sources/RNIDetachedView/RNIDetachedViewShadowNode.h
@@ -8,7 +8,11 @@
 #if __cplusplus
 #pragma once
 
+#if __has_include(<react_native_ios_utilities/RNIBaseViewShadowNode.h>)
+#import <react_native_ios_utilities/RNIBaseViewShadowNode.h>
+#else
 #include <react-native-ios-utilities/RNIBaseViewShadowNode.h>
+#endif
 
 #include <react/renderer/components/RNIUtilitiesSpec/EventEmitters.h>
 #include <react/renderer/components/RNIUtilitiesSpec/Props.h>

--- a/ios/Sources/RNIDummyTestView/RNIDummyTestView.h
+++ b/ios/Sources/RNIDummyTestView/RNIDummyTestView.h
@@ -7,7 +7,11 @@
 
 //#import <React/RCTComponent.h>
 
+#if __has_include(<react_native_ios_utilities/RNIBaseView.h>)
+#import <react_native_ios_utilities/RNIBaseView.h>
+#else
 #import <react-native-ios-utilities/RNIBaseView.h>
+#endif
 
 #if RCT_NEW_ARCH_ENABLED
 #import <React/RCTViewComponentView.h>

--- a/ios/Sources/RNIDummyTestView/RNIDummyTestView.mm
+++ b/ios/Sources/RNIDummyTestView/RNIDummyTestView.mm
@@ -8,11 +8,17 @@
 #import "RNIDummyTestView.h"
 #import "RNIBaseView.h"
 
-#import "react-native-ios-utilities/Swift.h"
-#import "react-native-ios-utilities/RNIContentViewParentDelegate.h"
-
-#import "react-native-ios-utilities/UIApplication+RNIHelpers.h"
+#if __has_include(<react_native_ios_utilities/Swift.h>)
+#import <react_native_ios_utilities/Swift.h>
+#import <react_native_ios_utilities/RNIContentViewParentDelegate.h>
+#import <react_native_ios_utilities/UIApplication+RNIHelpers.h>
+#import <react_native_ios_utilities/RNIObjcUtils.h>
+#else
+#import <react-native-ios-utilities/Swift.h>
+#import <react-native-ios-utilities/RNIContentViewParentDelegate.h>
+#import <react-native-ios-utilities/UIApplication+RNIHelpers.h>
 #import "react-native-ios-utilities/RNIObjcUtils.h"
+#endif
 
 #if RCT_NEW_ARCH_ENABLED
 #include "RNIDummyTestViewComponentDescriptor.h"

--- a/ios/Sources/RNIDummyTestView/RNIDummyTestViewComponentDescriptor.h
+++ b/ios/Sources/RNIDummyTestView/RNIDummyTestViewComponentDescriptor.h
@@ -10,7 +10,11 @@
 #include "RNIDummyTestViewShadowNode.h"
 #include "RNIBaseViewComponentDescriptor.h"
 
+#if __has_include(<react_native_ios_utilities/RNIBaseViewState.h>)
+#import <react_native_ios_utilities/RNIBaseViewState.h>
+#else
 #include <react-native-ios-utilities/RNIBaseViewState.h>
+#endif
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
 

--- a/ios/Sources/RNIDummyTestView/RNIDummyTestViewManager.mm
+++ b/ios/Sources/RNIDummyTestView/RNIDummyTestViewManager.mm
@@ -6,8 +6,13 @@
 //
 #import "RNIDummyTestView.h"
 
+#if __has_include(<react_native_ios_utilities/Swift.h>)
+#import <react_native_ios_utilities/Swift.h>
+#import <react_native_ios_utilities/RNIBaseViewUtils.h>
+#else
 #import "react-native-ios-utilities/Swift.h"
 #import "react-native-ios-utilities/RNIBaseViewUtils.h"
+#endif
 
 #import <objc/runtime.h>
 

--- a/ios/Sources/RNIDummyTestView/RNIDummyTestViewShadowNode.h
+++ b/ios/Sources/RNIDummyTestView/RNIDummyTestViewShadowNode.h
@@ -7,9 +7,16 @@
 #if __cplusplus
 #pragma once
 
+#if __has_include(<react_native_ios_utilities/RNIBaseViewShadowNode.h>)
+#import <react_native_ios_utilities/RNIBaseViewShadowNode.h>
+#import <react_native_ios_utilities/RNIBaseViewProps.h>
+#import <react_native_ios_utilities/RNIBaseViewEventEmitter.h>
+#else
 #include <react-native-ios-utilities/RNIBaseViewShadowNode.h>
 #include <react-native-ios-utilities/RNIBaseViewProps.h>
 #include <react-native-ios-utilities/RNIBaseViewEventEmitter.h>
+#endif
+
 
 #include <react/renderer/components/RNIUtilitiesSpec/EventEmitters.h>
 #include <react/renderer/components/RNIUtilitiesSpec/Props.h>

--- a/ios/Sources/RNIUtilitiesModule/RNIUtilitiesModule.mm
+++ b/ios/Sources/RNIUtilitiesModule/RNIUtilitiesModule.mm
@@ -6,10 +6,18 @@
 //
 
 #import "RNIUtilitiesModule.h"
+
+#if __has_include(<react_native_ios_utilities/Swift.h>)
+#import <react_native_ios_utilities/Swift.h>
+#import <react_native_ios_utilities/RNIViewRegistry.h>
+#import <react_native_ios_utilities/RNIViewCommandRequestHandling.h>
+#import <react_native_ios_utilities/RNIObjcUtils.h>
+#else
 #import "react-native-ios-utilities/Swift.h"
 #import "react-native-ios-utilities/RNIViewRegistry.h"
 #import "react-native-ios-utilities/RNIViewCommandRequestHandling.h"
 #import "react-native-ios-utilities/RNIObjcUtils.h"
+#endif
 
 #import <React/RCTBridge+Private.h>
 #import <React/RCTBridge.h>

--- a/ios/Sources/RNIViewRegistry/RNIViewRegistry.m
+++ b/ios/Sources/RNIViewRegistry/RNIViewRegistry.m
@@ -8,7 +8,11 @@
 #import "RNIViewRegistry.h"
 #import "RNIRegistrableView.h"
 
-#import "react-native-ios-utilities/RNIObjcUtils.h"
+#if __has_include(<react_native_ios_utilities/RNIObjcUtils.h>)
+#import <react_native_ios_utilities/RNIObjcUtils.h>
+#else
+#import <react-native-ios-utilities/RNIObjcUtils.h>
+#endif
 
 static BOOL SHOULD_LOG = NO;
 

--- a/ios/Sources/RNIWrapperView/RNIWrapperView.h
+++ b/ios/Sources/RNIWrapperView/RNIWrapperView.h
@@ -5,7 +5,11 @@
 //  Created by Dominic Go on 8/24/24.
 //
 
+#if __has_include(<react_native_ios_utilities/RNIBaseView.h>)
+#import <react_native_ios_utilities/RNIBaseView.h>
+#else
 #import <react-native-ios-utilities/RNIBaseView.h>
+#endif
 
 #if RCT_NEW_ARCH_ENABLED
 #import <React/RCTViewComponentView.h>

--- a/ios/Sources/RNIWrapperView/RNIWrapperView.mm
+++ b/ios/Sources/RNIWrapperView/RNIWrapperView.mm
@@ -7,17 +7,28 @@
 
 #import "RNIWrapperView.h"
 
-#import "react-native-ios-utilities/Swift.h"
-#import "react-native-ios-utilities/RNIContentViewParentDelegate.h"
-
-#import "react-native-ios-utilities/UIApplication+RNIHelpers.h"
-#import "react-native-ios-utilities/RNIObjcUtils.h"
+#if __has_include(<react_native_ios_utilities/Swift.h>)
+#import <react_native_ios_utilities/Swift.h>
+#import <react_native_ios_utilities/RNIContentViewParentDelegate.h>
+#import <react_native_ios_utilities/UIApplication+RNIHelpers.h>
+#import <react_native_ios_utilities/RNIObjcUtils.h>
+#else
+#import <react-native-ios-utilities/Swift.h>
+#import <react-native-ios-utilities/RNIContentViewParentDelegate.h>
+#import <react-native-ios-utilities/UIApplication+RNIHelpers.h>
+#import <react-native-ios-utilities/RNIObjcUtils.h>
+#endif
 
 #if RCT_NEW_ARCH_ENABLED
 #include "RNIWrapperViewComponentDescriptor.h"
-
-#include "react-native-ios-utilities/RNIBaseViewState.h"
+#if __has_include(<react_native_ios_utilities/RNIBaseViewState.h>)
+#import <react_native_ios_utilities/RNIBaseViewState.h>
+#import <react_native_ios_utilities/RNIBaseViewProps.h>
+#else
+#include <react-native-ios-utilities/RNIBaseViewState.h>
 #include "react-native-ios-utilities/RNIBaseViewProps.h"
+#endif
+
 
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>

--- a/ios/Sources/RNIWrapperView/RNIWrapperViewComponentDescriptor.h
+++ b/ios/Sources/RNIWrapperView/RNIWrapperViewComponentDescriptor.h
@@ -11,7 +11,12 @@
 #include "RNIWrapperViewShadowNode.h"
 #include "RNIBaseViewComponentDescriptor.h"
 
-#include "react-native-ios-utilities/RNIBaseViewState.h"
+#if __has_include(<react_native_ios_utilities/RNIBaseViewState.h>)
+#import <react_native_ios_utilities/RNIBaseViewState.h>
+#else
+#include <react-native-ios-utilities/RNIBaseViewState.h>
+#endif
+
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 
 

--- a/ios/Sources/RNIWrapperView/RNIWrapperViewManager.mm
+++ b/ios/Sources/RNIWrapperView/RNIWrapperViewManager.mm
@@ -8,7 +8,11 @@
 #import "RNIWrapperView.h"
 #import <objc/runtime.h>
 
+#if __has_include(<react_native_ios_utilities/RNIBaseViewUtils.h>)
+#import <react_native_ios_utilities/RNIBaseViewUtils.h>
+#else
 #import "react-native-ios-utilities/RNIBaseViewUtils.h"
+#endif
 
 #import "RCTBridge.h"
 #import <React/RCTViewManager.h>

--- a/ios/Sources/RNIWrapperView/RNIWrapperViewManager.mm
+++ b/ios/Sources/RNIWrapperView/RNIWrapperViewManager.mm
@@ -29,7 +29,7 @@ RCT_EXPORT_MODULE(RNIWrapperView)
 #ifndef RCT_NEW_ARCH_ENABLED
 - (UIView *)view
 {
-  return [[RNIWrapperView new] initWithBridge:self.bridge];
+  return [[RNIWrapperView alloc] initWithBridge:self.bridge];
 }
 #endif
 

--- a/ios/Sources/RNIWrapperView/RNIWrapperViewShadowNode.h
+++ b/ios/Sources/RNIWrapperView/RNIWrapperViewShadowNode.h
@@ -8,7 +8,11 @@
 #if __cplusplus
 #pragma once
 
+#if __has_include(<react_native_ios_utilities/RNIBaseViewShadowNode.h>)
+#import <react_native_ios_utilities/RNIBaseViewShadowNode.h>
+#else
 #include <react-native-ios-utilities/RNIBaseViewShadowNode.h>
+#endif
 
 #include <react/renderer/components/RNIUtilitiesSpec/EventEmitters.h>
 #include <react/renderer/components/RNIUtilitiesSpec/Props.h>

--- a/ios/Swift.h
+++ b/ios/Swift.h
@@ -4,7 +4,7 @@
 // Otherwise, it's available only locally with double-quoted imports.
 //
 #if __has_include(<react_native_ios_utilities/react_native_ios_utilities-Swift.h>)
-#import "<react_native_ios_utilities/react_native_ios_utilities-Swift.h>"
+#import "react_native_ios_utilities/react_native_ios_utilities-Swift.h"
 #else
 #import "react_native_ios_utilities-Swift.h"
 #endif

--- a/react-native-ios-utilities.podspec
+++ b/react-native-ios-utilities.podspec
@@ -42,6 +42,7 @@ Pod::Spec.new do |s|
     '"${PODS_ROOT}/Headers/Public/React-hermes"',
     '"${PODS_ROOT}/Headers/Public/hermes-engine"',
     '"${PODS_ROOT}/Headers/Private/React-Core"',
+    '"${PODS_CONFIGURATION_BUILD_DIR}/React-rendererconsistency/React_rendererconsistency.framework/Headers"',
   ]
 
   # Swift/Objective-C compatibility

--- a/yarn.lock
+++ b/yarn.lock
@@ -10701,7 +10701,7 @@ __metadata:
     react-native: 0.75.2
     react-native-codegen: 0.71.3
     react-native-safe-area-context: ^4.10.8
-    react-native-screens: ^3.34.0
+    react-native-screens: 4.3.0
   languageName: unknown
   linkType: soft
 
@@ -10739,16 +10739,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-screens@npm:^3.34.0":
-  version: 3.34.0
-  resolution: "react-native-screens@npm:3.34.0"
+"react-native-screens@npm:4.3.0":
+  version: 4.3.0
+  resolution: "react-native-screens@npm:4.3.0"
   dependencies:
     react-freeze: ^1.0.0
     warn-once: ^0.1.0
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 28c1f6e556c318ffcbd79d153b9612cc8a0b8d8b70f909d3cde2fd6d0586a7c151a449e57400d8996f4ee6c3b5140c5c4f643a427e974f6dc573b2bcd8eb7356
+  checksum: b43ae4145e264582732ec53c78ba88de678c8ce7f9687b0526bf647c7d1ea8311ee821945848a55fb04f145bf8cae189d2d4e0f49e52571cb23acf083f2df858
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes https://github.com/dominicstop/react-native-ios-utilities/issues/10

Xcode will [replace hyphens with underscores when building Frameworks](https://stackoverflow.com/questions/26012565/in-swift-how-to-import-a-target-with-dash-in-its-name). So if you install this project with:

```
USE_FRAMEWORKS="static" pod install
```

All of the generated paths will be converted from `react-native-ios-utilities` to `react_native_ios_utilities`.

This PR uses a preprocessor directive to check if the imported headers exist at the path with underscores. If they do, then we use the underscore imports. If not, we use the old ones.

## Other options to consider

1. It might make sense to just rename the module entirely to be something like `ReactNativeIosUtilities` to be more conventional. 
2. You could use `module_name` to set the name to something different, but there's no way to include hyphens in the module name for bridging, so there would still be this conditional logic.
3. Set up a project-specific macro to do this conditional work
4. Update the header search paths so they include both `react-native-ios-utilities` and `react_native_ios_utilities`. That way you could just use relative paths to the headers. I strongly considered this option, but I don't love the idea of collision possibilities or ambiguity.

So here, I just went through file-by-file and cleaned up the headers. This fixes one problem (headers for the project being incorrect), but leaves another issue (I'll write about that later on).

Here is an example of one of the errors I've observed on the example app in `master`, when `USE_FRAMEWORKS` is either `static` or `dynamic`: 

<img width="1067" alt="Screenshot 2024-11-29 at 6 23 01 PM" src="https://github.com/user-attachments/assets/6f59938b-7b5d-4c99-b58a-d9571f0e3196">

With this PR, these errors go away (they're pervasive in all the header imports).

## Remaining issues

Unfortunately, I'm still running into some issues in the React Native UIManager class, which is throwing this error:

```
/Users/tylerwilliams/Library/Developer/Xcode/DerivedData/IosUtilitiesExample-gxuxatrkcpajlmgczqsxbhasxken/Build/Products/Debug-iphonesimulator/React-Fabric/React_Fabric.framework/Headers/react/renderer/uimanager/UIManager.h:17:10 'react/renderer/consistency/ShadowTreeRevisionConsistencyManager.h' file not found
```

I found a similar looking issue in Expo: https://github.com/expo/expo/issues/31092, which they solved [by adding React-rendererconsistency](https://github.com/expo/expo/pull/31100/files#diff-d3922893d1b70271fc417bb831ae17ff246fe64c9a75f61d36884d91f38db2a7R111-R113) as a dependency.

However, that patch doesn't change anything, and I actually see that being installed through Pods already. I'm guessing there's some problem with the header/framework lookup paths, but I'm stumped at this point. @dominicstop - I would love your thoughts on that. Happy to continue doing the work if you have any insights into how to troubleshoot that.

## Checking locally

1. Pull down this branch
2. Clean dependencies and reinstall
3. `cd example/ios`
4. `pod deintegrate && rm -rf Pods/ && rm -rf Podfile.lock && NO_FLIPPER="1" USE_FRAMEWORKS="static" RCT_NEW_ARCH_ENABLED="1" pod install --repo-update && open IosUtilitiesExample.xcworkspace` (just to be like, super sure about all of the dependencies being clean
5. Build
6. See the *new* missing header error.