### PR TITLE
fix build on RN 0.77

### DIFF
--- a/ios/Sources/RNIBaseView/RNIBaseViewShadowNode.h
+++ b/ios/Sources/RNIBaseView/RNIBaseViewShadowNode.h
@@ -125,34 +125,64 @@ public:
     
     if(stateData.shouldSetMinWidth) {
       doesNeedLayout = true;
+      
+#if REACT_NATIVE_TARGET_VERSION >= 77
+      yogaStyle.setMinDimension(
+        yoga::Dimension::Width,
+        yoga::StyleLength::points(stateData.minSize.width)
+      );
+#else
       yogaStyle.setMinDimension(
         yoga::Dimension::Width,
         yoga::value::points(stateData.minSize.width)
       );
+#endif
     };
     
     if(stateData.shouldSetMinHeight) {
       doesNeedLayout = true;
+    
+#if REACT_NATIVE_TARGET_VERSION >= 77
+      yogaStyle.setMinDimension(
+        yoga::Dimension::Height,
+        yoga::StyleLength::points(stateData.minSize.height)
+      );
+#else
       yogaStyle.setMinDimension(
         yoga::Dimension::Height,
         yoga::value::points(stateData.minSize.height)
       );
+#endif
     };
     
     if(stateData.shouldSetMaxWidth) {
       doesNeedLayout = true;
+#if REACT_NATIVE_TARGET_VERSION >= 77
+      yogaStyle.setMinDimension(
+        yoga::Dimension::Width,
+        yoga::StyleLength::points(stateData.maxSize.width)
+      );
+#else
       yogaStyle.setMinDimension(
         yoga::Dimension::Width,
         yoga::value::points(stateData.maxSize.width)
       );
+#endif
     };
     
     if(stateData.shouldSetMaxHeight) {
       doesNeedLayout = true;
+#if REACT_NATIVE_TARGET_VERSION >= 77
+      yogaStyle.setMinDimension(
+        yoga::Dimension::Height,
+        yoga::StyleLength::points(stateData.maxSize.height)
+      );
+#else
       yogaStyle.setMinDimension(
         yoga::Dimension::Height,
         yoga::value::points(stateData.maxSize.height)
       );
+#endif
     };
     
     if(doesNeedLayout){


### PR DESCRIPTION
Hello @dominicstop 

This library fails to build on RN 0.77 because it uses `yoga::value` - `yoga::value` is unavailable starting from 0.77, which means we have to switch to `yoga::StyleLength`. See: https://github.com/software-mansion/react-native-svg/pull/2582

I've tested this in my own app which uses iOS context menu on RN 0.77 - the build passes, and from my initial testing everything still works fine.

I also tried updating the example app to RN 0.77 but encountered some issues, which I think are not related to this change - I'd appreciate if you could look into it. Maybe something related to old arch support?

![CleanShot 2025-01-21 at 18 16 26@2x](https://github.com/user-attachments/assets/a9524eb6-f7aa-442d-b6af-7e9b4db9c47c)
