### PR TITLE
fix: RN 0.79 build

### DIFF
--- a/react-native-ios-utilities.podspec
+++ b/react-native-ios-utilities.podspec
@@ -144,6 +144,8 @@ Pod::Spec.new do |s|
   if use_hermes && reactNativeTargetVersion >= 78
     add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
     add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
+    # bring in the new C-API runtime headers for React Native 0.79
+    add_dependency(s, "React-jsitooling", :framework_name => 'jsitooling')
   end
 
   s.dependency 'React-Core'


### PR DESCRIPTION
Bring in the new C-API runtime headers (JSRuntimeFactoryCAPI.h) via the React-jsitooling pod so that builds on React Native 0.79+ no longer fail due to the removed JSRuntimeFactory.h.

Fixes #22 