### PR TITLE
do not install folly manually if prebuilt RN deps are used

### DIFF
--- a/react-native-ios-utilities.podspec
+++ b/react-native-ios-utilities.podspec
@@ -28,7 +28,11 @@ use_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 folly_version = '2022.05.16.00'
-folly_compiler_flags = get_folly_config()[:compiler_flags]
+folly_compiler_flags = (get_folly_config()[:compiler_flags] || '').strip
+base_flags = "-DREACT_NATIVE_TARGET_VERSION=#{reactNativeTargetVersion}"
+
+compiler_flags = base_flags.dup
+
 
 linkage = ENV['USE_FRAMEWORKS']
 reactNativeTargetVersionOverride = ENV['REACT_NATIVE_TARGET_VERSION']
@@ -47,7 +51,9 @@ if reactNativeTargetVersionOverride
 end
 
 fabric_compiler_flags = '-DRN_FABRIC_ENABLED -DRCT_NEW_ARCH_ENABLED'
-compiler_flags = folly_compiler_flags + ' ' + "-DREACT_NATIVE_TARGET_VERSION=#{reactNativeTargetVersion}"
+if ENV['RCT_USE_RN_DEP'] != '1'
+  compiler_flags = [folly_compiler_flags, base_flags].reject(&:empty?).join(' ')
+end
 
 if use_hermes
   compiler_flags << ' -DUSE_HERMES'
@@ -165,7 +171,9 @@ Pod::Spec.new do |s|
 
   if fabric_enabled
     s.dependency 'React-RCTFabric'
-    s.dependency 'RCT-Folly', folly_version
+    if ENV['RCT_USE_RN_DEP'] != '1'
+      s.dependency 'RCT-Folly', folly_version
+    end
   end
 
   s.dependency 'DGSwiftUtilities', '~> 0.46'


### PR DESCRIPTION
Hello @dominicstop - starting from React Native 0.80, there is an ability to use prebuilt RN dependencies. See: https://reactnative.dev/blog/2025/06/12/react-native-0.80#experimental---react-native-ios-dependencies-are-now-prebuilt When this is done, libraries that configure Folly manually clash with this approach, resulting in build errors. Since this library configures Folly manually, we need to account for this.

Would you be able to check this PR out?