### PR TITLE
fix FollyConvert.h for static frameworks

### DIFF
--- a/ios/Sources/ObjcHelpers/RNIObjcUtils.mm
+++ b/ios/Sources/ObjcHelpers/RNIObjcUtils.mm
@@ -19,7 +19,7 @@
 #if __cplusplus
 #import <folly/dynamic.h>
 #import <React/RCTConversions.h>
-#import <React/RCTFollyConvert.h>
+#import "RNIUtilitiesFollyConvert.h"
 
 #include <react/renderer/core/LayoutMetrics.h>
 #include <react/renderer/graphics/Rect.h>

--- a/ios/Sources/RNIBaseView/RNIBaseView.mm
+++ b/ios/Sources/RNIBaseView/RNIBaseView.mm
@@ -27,7 +27,7 @@
 
 #import "RCTFabricComponentsPlugins.h"
 
-#import <React/RCTFollyConvert.h>
+#import "RNIUtilitiesFollyConvert.h"
 #import <React/RCTSurfaceTouchHandler.h>
 
 #include <react/renderer/core/ConcreteComponentDescriptor.h>

--- a/ios/Sources/RNIUtilitiesModule/RNIUtilitiesFollyConvert.h
+++ b/ios/Sources/RNIUtilitiesModule/RNIUtilitiesFollyConvert.h
@@ -1,0 +1,15 @@
+#ifdef RCT_NEW_ARCH_ENABLED
+
+#if __has_include(<react/utils/FollyConvert.h>)
+  // static libs / header maps (no use_frameworks!)
+  #import <react/utils/FollyConvert.h>
+#elif __has_include("FollyConvert.h")
+  // `use_frameworks! :linkage => :static` users will need to import FollyConvert this way
+  #import "FollyConvert.h"
+#elif __has_include("RCTFollyConvert.h")
+  #import "RCTFollyConvert.h"
+#else
+  #error "FollyConvert.h not found. Ensure React-utils & RCT-Folly pods are installed."
+#endif
+
+#endif

--- a/ios/Sources/RNIUtilitiesModule/RNIUtilitiesModule.mm
+++ b/ios/Sources/RNIUtilitiesModule/RNIUtilitiesModule.mm
@@ -19,7 +19,7 @@
 
 #import <folly/dynamic.h>
 #import <React/RCTConversions.h>
-#import <React/RCTFollyConvert.h>
+#import "RNIUtilitiesFollyConvert.h"
 
 #include <jsi/jsi.h>
 #include <string>


### PR DESCRIPTION
As a follow up to https://github.com/dominicstop/react-native-ios-utilities/pull/30#issuecomment-3223764310, the FollyConvert header needs to be imported differently when the project is using frameworks (e.g. rn-firebase) and thus can't use precompiled RN libraries yet.
cc @nandorojo 